### PR TITLE
Support for multi character/multibyte FNC delimiters

### DIFF
--- a/src/gs1/dataReaders.js
+++ b/src/gs1/dataReaders.js
@@ -25,7 +25,7 @@ exports.variableLength = (maxLength) => ({
   const characters = []
 
   for (const character of barcode) {
-    if (character === fnc || characters.length === maxLength) break
+    if ((character === fnc || (fnc.length > 1 && character === fnc[0])) || characters.length === maxLength) break
     characters.push(character)
   }
 

--- a/src/gs1/parser.spec.js
+++ b/src/gs1/parser.spec.js
@@ -95,6 +95,50 @@ describe('unit', () => {
       originalBarcode: `101337${FNC}0112345678901234`,
     })
   })
+
+  it('allows multi-character FNC', () => {
+    const fnc = '{GS}'
+    const barcode = `107473020${fnc}217473020-000`
+
+    expect(parser({ barcode, fnc })).toMatchObject({
+      elements: [
+        {
+          ai: '10',
+          raw: `7473020${fnc}`,
+          title: 'BATCH/LOT',
+          value: '7473020',
+        },
+        {
+          ai: '21',
+          raw: '7473020-000',
+          title: 'SERIAL',
+          value: '7473020-000',
+        },
+      ],
+    })
+  })
+
+  it('allows multibyte (emoji) FNC', () => {
+    const fnc = '🥉'
+    const barcode = `107473020${fnc}217473020-000`
+
+    expect(parser({ barcode, fnc })).toMatchObject({
+      elements: [
+        {
+          ai: '10',
+          raw: `7473020${fnc}`,
+          title: 'BATCH/LOT',
+          value: '7473020',
+        },
+        {
+          ai: '21',
+          raw: '7473020-000',
+          title: 'SERIAL',
+          value: '7473020-000',
+        },
+      ],
+    })
+  })
 })
 
 describe('live examples parse as expected', () => {


### PR DESCRIPTION
Depending on how your barcode reader transforms inputs into text representations, the FNC is sometimes literally `"<GS>"` or `"{GS}"` instead of `String.fromCharCode(29)`. This PR adds support for FNCs that are either >1 characters or use multibyte characters (🤡!)